### PR TITLE
remove duplicate underscores when pulling barcode to the front

### DIFF
--- a/dropboxhandler/dropboxhandler.py
+++ b/dropboxhandler/dropboxhandler.py
@@ -78,6 +78,8 @@ def generate_openbis_name(path):
     cleaned_name = fstools.clean_filename(path)
     barcode = extract_barcode(cleaned_name)
     name = cleaned_name.replace(barcode, "")
+    if name.startswith('_'):
+        name = name[1:]
     return barcode + '_' + name
 
 


### PR DESCRIPTION
if the lab already uses an underscore ('_') to separate barcodes and the rest of the file name, cleaning up the file name lead to doubled underscores. this PR fixes that