### PR TITLE
ignore missing or too many barcodes in file name, but log them

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,18 @@
+==========
+Changelog
+==========
+
+This project adheres to `Semantic Versioning <https://semver.org/>`_.
+
+1.0.1 (2021-07-15)
+------------------
+
+**Added**
+
+* It is now possible to pass incoming files/folders to openBIS even without a barcode, provided there are rules for such cases in the yaml file
+
+**Fixed**
+
+**Dependencies**
+
+**Deprecated**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.0.1 (2021-07-15)
+1.1.0 (2021-07-15)
 ------------------
 
 **Added**

--- a/dropboxhandler/dropboxhandler.py
+++ b/dropboxhandler/dropboxhandler.py
@@ -76,7 +76,11 @@ def generate_openbis_name(path):
     'QJFDC010EU_stpidname.raw'
     """
     cleaned_name = fstools.clean_filename(path)
-    barcode = extract_barcode(cleaned_name)
+    try:
+        barcode = extract_barcode(cleaned_name)
+    except ValueError:
+        logger.warn("No or more than one barcode in file: %s. Trying to find respective rule.", path)
+        return name
     name = cleaned_name.replace(barcode, "")
     return barcode + '_' + name
 


### PR DESCRIPTION
We want to allow the handling of datasets that carry barcode identifiers in files or subfolders as opposed to the name. this moves responsibility away from the basic functionality of the dropboxhandler to its config and/or subsequent ETL scripts.